### PR TITLE
install glibc-compact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o
 # Final stage
 FROM alpine:latest
 
-# Install runtime dependencies (just git and ca-certificates)
-RUN apk add --no-cache ca-certificates git
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates git gcompat
 
 # Copy the binary from builder stage
 COPY --from=builder /app/codegen /usr/local/bin/codegen


### PR DESCRIPTION
/kind bug

Previously built image failed in runtime reporting `pkl: no such file`, however, it's downloaded properly:

```console
{"component":"unset","error":"failed to load account from /var/tmp/gitrepo1138019194/infra/account.pkl: fork/exec /usr/local/bin/pkl: no such file or directory","event-GUID":"3a1aceb0-44ff-11f0-8e5f-de447aa0cf34","event-type":"pull_request","file":"/go/pkg/mod/github.com/bombsimon/logrusr/v4@v4.1.0/logrusr.go:133","func":"github.com/bombsimon/logrusr/v4.(*logrusr).Error","level":"error","msg":"kubecon-codegen failed.","plugin":"kubecon-codegen","severity":"error","time":"2025-06-09T06:59:04Z"}
``` 

```console
/ # ldd $(which pkl)
	/lib64/ld-linux-x86-64.so.2 (0x7a091ea48000)
	libz.so.1 => /usr/lib/libz.so.1 (0x7a091ea2d000)
	libdl.so.2 => /lib64/ld-linux-x86-64.so.2 (0x7a091ea48000)
	libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7a091ea48000)
	librt.so.1 => /lib64/ld-linux-x86-64.so.2 (0x7a091ea48000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7a091ea48000)
Error relocating /usr/local/bin/pkl: __strtok_r: symbol not found
Error relocating /usr/local/bin/pkl: __strdup: symbol not found
```

It's very likely Alpine Linux uses musl libc but the pkl binary was compiled for glibc. 