### PR TITLE
fix: correct the logic of delete auto-generated files

### DIFF
--- a/pkg/generator/codegen.go
+++ b/pkg/generator/codegen.go
@@ -264,9 +264,13 @@ func contains(slice []string, item string) bool {
 // delete all previously-generated files that start with
 // # Code generated
 func deleteGeneratedFiles(fs afero.Fs, dstDir string) error {
-	return afero.Walk(fs, dstDir, func(path string, _ os.FileInfo, err error) error {
+	return afero.Walk(fs, dstDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if info.IsDir() {
+			return nil
 		}
 
 		file, err := fs.Open(path)

--- a/pkg/git/resource_worker.go
+++ b/pkg/git/resource_worker.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	checkoutBranchFmt = "auto-checkout-%d-to-%s%s"
-	GitHubURL         = "https://github.com/"
+	GitHubURL         = "https://github.com"
 
 	ErrNothingToCommit          = errors.New("nothing to commit")
 	ErrPullRequestAlreadyExists = errors.New("pull request already exists")


### PR DESCRIPTION
/kind bug

Fix an issue that auto-generated files are not pruned when the user delete or renamed the tenant files.