### PR TITLE
adapt to tag v0.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Huang-Wei/25-kubecon-jp-codegen
 go 1.23.8
 
 require (
-	github.com/Huang-Wei/25-kubecon-jp v0.0.2
+	github.com/Huang-Wei/25-kubecon-jp v0.0.4
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/testgrid v0.0.123 h1:S5LE2LjkPsUlyt7blkIgwajiUfgFzv5s17+TkyKDfnI=
 github.com/GoogleCloudPlatform/testgrid v0.0.123/go.mod h1:4Ojwl21NNySkM1rG8hT9K2bugPX9fIrc2hC+GHegLR8=
-github.com/Huang-Wei/25-kubecon-jp v0.0.2 h1:igoT+hzjV/JwHsN0hyKOK+lXHpVeXJUj2Ge7x/mZrKc=
-github.com/Huang-Wei/25-kubecon-jp v0.0.2/go.mod h1:nGrbuJFhWsh0eHgdbReph9JNwcpM0fVhEQyNdaA9gbQ=
+github.com/Huang-Wei/25-kubecon-jp v0.0.4 h1:0RC21R5/EFG5YvHSP9LBHvYdy1F/Bnp3YFMY8sRFxIc=
+github.com/Huang-Wei/25-kubecon-jp v0.0.4/go.mod h1:nGrbuJFhWsh0eHgdbReph9JNwcpM0fVhEQyNdaA9gbQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=

--- a/pkg/generator/codegen.go
+++ b/pkg/generator/codegen.go
@@ -13,10 +13,11 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/Huang-Wei/25-kubecon-jp-codegen/pkg/internal"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector/key"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector/operator"
 	"github.com/Huang-Wei/25-kubecon-jp/go/generated/infra/account"
 	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/resource"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector/operator"
 )
 
 const (
@@ -202,12 +203,12 @@ func (cg *Codegen) generateOutputPath(pathCtx pathContext, templatesPath string)
 	return pathBuilder.String(), nil
 }
 
-func envMatches(accountTags map[string]string, tuple *internal.TenantTuple) bool {
+func envMatches(accountTags map[key.Key]string, tuple *internal.TenantTuple) bool {
 	env := accountTags["env"]
 	return env == "" || env == tuple.Env
 }
 
-func selectorMatches(accountTags map[string]string, selector []*selector.Requirment) bool {
+func selectorMatches(accountTags map[key.Key]string, selector []*selector.Requirment) bool {
 	if len(selector) == 0 {
 		return true
 	}
@@ -222,9 +223,8 @@ func selectorMatches(accountTags map[string]string, selector []*selector.Requirm
 	return true
 }
 
-func requirementMatches(tags map[string]string, req *selector.Requirment) bool {
-	keyStr := string(req.Key) // Convert key.Key to string
-	tagValue, exists := tags[keyStr]
+func requirementMatches(tags map[key.Key]string, req *selector.Requirment) bool {
+	tagValue, exists := tags[req.Key]
 
 	switch req.Operator {
 	case operator.In:

--- a/pkg/generator/codegen_test.go
+++ b/pkg/generator/codegen_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/Huang-Wei/25-kubecon-jp-codegen/pkg/internal"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector/key"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector/operator"
 	"github.com/Huang-Wei/25-kubecon-jp/go/generated/infra/account"
 	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/resource"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector/key"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector/operator"
 )
 
 func TestFanOutArtifacts(t *testing.T) {
@@ -95,17 +95,17 @@ namePrefix: "tenant-X-aws-1234-us-east-1-"
 				{
 					AccountID:     "1234",
 					CloudProvider: "aws",
-					Tags: map[string]string{
-						string(key.CloudProvider): "aws",
-						string(key.Env):           "prod",
+					Tags: map[key.Key]string{
+						key.CloudProvider: "aws",
+						key.Env:           "prod",
 					},
 				},
 				{
 					AccountID:     "senzu-bean",
 					CloudProvider: "gcp",
-					Tags: map[string]string{
-						string(key.CloudProvider): "gcp",
-						string(key.Env):           "dev",
+					Tags: map[key.Key]string{
+						key.CloudProvider: "gcp",
+						key.Env:           "dev",
 					},
 				},
 			},

--- a/pkg/git/resource_worker_test.go
+++ b/pkg/git/resource_worker_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/Huang-Wei/25-kubecon-jp-codegen/pkg/internal"
+	"github.com/Huang-Wei/25-kubecon-jp/go/generated/common/selector"
 	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/resource"
-	"github.com/Huang-Wei/25-kubecon-jp/go/generated/tenant/selector"
 )
 
 // pkl-gen-go evaluates an empty Listing as a non-nil slice instead of nil.


### PR DESCRIPTION
Adapt to tag v0.0.4 which enforce a typed `Key` struct in AccountConfig and refactored the package of SelectorConfig related Go structs.

/kind cleanup